### PR TITLE
Remove redundant Mocha configuration

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,2 +1,0 @@
-require:
-  - '@babel/register'


### PR DESCRIPTION
Now that we're using Jest for the test suite, remove the Mocha-specific configuration file.
