### PR TITLE
Fix burger nav in menu by restoring Bootstrap JS

### DIFF
--- a/src/javascript/menu.js
+++ b/src/javascript/menu.js
@@ -1,0 +1,1 @@
+import "bootstrap/js/dist/collapse";

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,7 +3,11 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
-  entry: "./src/javascript/upload.jsx",
+  entry: {
+    menu: "./src/javascript/menu.js",
+    upload: "./src/javascript/upload.jsx",
+  },
+
   output: {
     filename: "[name].[contenthash].js",
     path: path.resolve(__dirname, "dist"),
@@ -36,22 +40,25 @@ module.exports = {
   plugins: [
     new CopyPlugin([
       {
-        from: "index.html",
-        context: "src/",
-      },
-      {
-        from: "generate-csv.html",
-        context: "src/",
-      },
-      {
         from: "examples/*",
         context: "src/",
       },
     ]),
 
     new HtmlWebpackPlugin({
+      template: "./src/index.html",
+      filename: "index.html",
+      chunks: ["menu"],
+    }),
+    new HtmlWebpackPlugin({
+      template: "./src/generate-csv.html",
+      filename: "generate-csv.html",
+      chunks: ["menu"],
+    }),
+    new HtmlWebpackPlugin({
       template: "./src/upload-csv.html",
       filename: "upload-csv.html",
+      chunks: ["menu", "upload"],
     }),
   ],
 };


### PR DESCRIPTION
When re-implementing the UI in React, we removed the inclusion of Bootstrap's Collapse plugin's JavaScript thinking it was no longer used.  However, it is still used for the dropdown menu on narrow screen widths so restore it across all HTML pages.

This means we need to process index.html and generate-csv.html with the HTML Webpack plugin again and configure it to only include the code needed for the collapsing menu. We also add this to the existing configuration for the main part of the application.
