### PR TITLE
Copy the shareable URL to the clipboard

### DIFF
--- a/src/javascript/components/Results.jsx
+++ b/src/javascript/components/Results.jsx
@@ -12,6 +12,11 @@ const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
 
   const sharingID = rowsToURL(rows, radianceOrIrradiance);
 
+  const copySharingURL = ({ target }) => {
+    target.setSelectionRange(0, target.value.length);
+    document.execCommand("copy");
+  };
+
   return (
     <div className="row">
       <div className="col">
@@ -60,11 +65,18 @@ const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
           Step 5. Share an online version of this report.
         </h2>
 
-        <p>
-          <a href={`/u/${sharingID}`} className="btn btn-outline-secondary">
-            Share this report with others
-          </a>
-        </p>
+        <div className="form-group">
+          <input
+            type="text"
+            className="form-control"
+            value={`${window.location.origin}/u/${sharingID}`}
+            onClick={copySharingURL}
+            readOnly
+          />
+          <small className="form-text text-muted">
+            Click above to copy the URL to your clipboard
+          </small>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<img width="1152" alt="Screenshot 2020-11-03 at 08 56 12" src="https://user-images.githubusercontent.com/287/97965533-7046bb80-1db2-11eb-9ad8-a1b3e7bfcf13.png">

Trello: https://trello.com/c/tAY1u0fS/25-ability-to-share-urls

Rather than giving the user a button as a means to share a read-only version of their report, show them the full URL in a text field.  Clicking that text field will then copy the URL to their clipboard.
