### PR TITLE
Use the users measurement labels everywhere

### DIFF
--- a/src/javascript/chart.js
+++ b/src/javascript/chart.js
@@ -1,6 +1,6 @@
 import Chart from "chart.js";
 import { mapSamples } from "./rows";
-import { sampleTitles, radianceOrIrradianceSIUnit } from "./helpers";
+import { radianceOrIrradianceSIUnit } from "./helpers";
 
 const generateHues = (sampleCount) => {
   const hues = [];
@@ -16,11 +16,12 @@ const createChart = (
   radianceOrIrradiance,
   rows,
   sampleCount,
+  csvHeader,
   yAxisScaling
 ) => {
   const datasets = [];
   const hues = generateHues(sampleCount);
-  const labels = sampleTitles(sampleCount);
+  const [, ...labels] = csvHeader;
   let data = rows;
   let yAxisLabel = `Spectral ${radianceOrIrradiance} [${radianceOrIrradianceSIUnit(
     radianceOrIrradiance

--- a/src/javascript/components/CalculationTable.jsx
+++ b/src/javascript/components/CalculationTable.jsx
@@ -2,10 +2,11 @@ import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
 import { calculate } from "../calculations";
 import CalculationTableCSV from "./CalculationTableCSV";
-import { asDecimal, asExponential, sampleTitles } from "../helpers";
+import { asDecimal, asExponential } from "../helpers";
 
-const CalculationTableHeader = ({ sampleCount }) => {
-  const titles = ["Condition", ...sampleTitles(sampleCount)];
+const CalculationTableHeader = ({ csvHeader }) => {
+  const [, ...labels] = csvHeader;
+  const titles = ["Condition", ...labels];
 
   return (
     <thead>
@@ -19,7 +20,7 @@ const CalculationTableHeader = ({ sampleCount }) => {
 };
 
 CalculationTableHeader.propTypes = {
-  sampleCount: PropTypes.number.isRequired,
+  csvHeader: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 const CalculationTableRow = ({ heading, samples, exponentialNotation }) => {
@@ -47,7 +48,12 @@ CalculationTableRow.propTypes = {
   samples: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
-const CalculationTable = ({ radianceOrIrradiance, rows, sampleCount }) => {
+const CalculationTable = ({
+  radianceOrIrradiance,
+  rows,
+  sampleCount,
+  csvHeader,
+}) => {
   const calculation = useMemo(() => calculate(rows, sampleCount), [
     rows,
     sampleCount,
@@ -56,10 +62,10 @@ const CalculationTable = ({ radianceOrIrradiance, rows, sampleCount }) => {
     () =>
       CalculationTableCSV({
         radianceOrIrradiance,
-        sampleCount,
+        csvHeader,
         ...calculation,
       }),
-    [radianceOrIrradiance, sampleCount, calculation]
+    [radianceOrIrradiance, csvHeader, calculation]
   );
 
   const {
@@ -129,7 +135,7 @@ const CalculationTable = ({ radianceOrIrradiance, rows, sampleCount }) => {
         </div>
       </div>
       <table className="table table-sm mt-3 result-table">
-        <CalculationTableHeader sampleCount={sampleCount} />
+        <CalculationTableHeader csvHeader={csvHeader} />
         <tbody>
           <CalculationTableRow
             heading={
@@ -261,6 +267,7 @@ CalculationTable.propTypes = {
   rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired,
   sampleCount: PropTypes.number.isRequired,
   radianceOrIrradiance: PropTypes.oneOf(["radiance", "irradiance"]).isRequired,
+  csvHeader: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default CalculationTable;

--- a/src/javascript/components/CalculationTableCSV.js
+++ b/src/javascript/components/CalculationTableCSV.js
@@ -1,9 +1,8 @@
 import Papa from "papaparse";
-import { sampleTitles } from "../helpers";
 
 const CalculationTableCSV = ({
   radianceOrIrradiance,
-  sampleCount,
+  csvHeader,
   luminanceTotals,
   chromaticity31,
   chromaticity64,
@@ -20,9 +19,10 @@ const CalculationTableCSV = ({
     radianceOrIrradiance === "radiance" ? "mW ⋅ m⁻² ⋅ sr" : "mW ⋅ m⁻²";
   const equivalentDaylightUnit =
     radianceOrIrradiance === "radiance" ? "EDL [cd/m²]" : "EDI [lux]";
+  const [, ...labels] = csvHeader;
 
   const csv = Papa.unparse([
-    ["Condition", ...sampleTitles(sampleCount)],
+    ["Condition", ...labels],
     [
       radianceOrIrradiance === "radiance"
         ? "Luminance [cd/m²]"

--- a/src/javascript/components/Chart.jsx
+++ b/src/javascript/components/Chart.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import PropTypes from "prop-types";
 import createChart from "../chart";
 
-const Chart = ({ radianceOrIrradiance, rows, sampleCount }) => {
+const Chart = ({ radianceOrIrradiance, rows, sampleCount, csvHeader }) => {
   const chartRef = useRef();
   const [yAxisScaling, setYAxisScaling] = useState("raw");
 
@@ -19,6 +19,7 @@ const Chart = ({ radianceOrIrradiance, rows, sampleCount }) => {
         radianceOrIrradiance,
         rows,
         sampleCount,
+        csvHeader,
         yAxisScaling
       );
     }
@@ -28,7 +29,7 @@ const Chart = ({ radianceOrIrradiance, rows, sampleCount }) => {
         chart.destroy();
       }
     };
-  }, [radianceOrIrradiance, rows, sampleCount, yAxisScaling]);
+  }, [radianceOrIrradiance, rows, sampleCount, csvHeader, yAxisScaling]);
 
   return (
     <section>
@@ -85,6 +86,7 @@ Chart.propTypes = {
   radianceOrIrradiance: PropTypes.oneOf(["radiance", "irradiance"]).isRequired,
   rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired,
   sampleCount: PropTypes.number.isRequired,
+  csvHeader: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default Chart;

--- a/src/javascript/components/Report.jsx
+++ b/src/javascript/components/Report.jsx
@@ -8,7 +8,7 @@ import { urlToRows } from "../sharing";
 const Report = () => {
   const { id } = useParams();
 
-  const [rows, radianceOrIrradiance] = urlToRows(id);
+  const [rows, radianceOrIrradiance, csvHeader] = urlToRows(id);
   const sampleCount = rows[0].length - 1;
 
   return (
@@ -30,6 +30,7 @@ const Report = () => {
           radianceOrIrradiance={radianceOrIrradiance}
           rows={rows}
           sampleCount={sampleCount}
+          csvHeader={csvHeader}
         />
 
         <h2 className="my-3">Stimulus specification tables</h2>
@@ -38,6 +39,7 @@ const Report = () => {
           rows={rows}
           sampleCount={sampleCount}
           radianceOrIrradiance={radianceOrIrradiance}
+          csvHeader={csvHeader}
         />
 
         <h2 className="my-3">Full spectral power distribution</h2>

--- a/src/javascript/components/Results.jsx
+++ b/src/javascript/components/Results.jsx
@@ -5,12 +5,12 @@ import SpectraTable from "./SpectraTable";
 import Chart from "./Chart";
 import { rowsToURL } from "../sharing";
 
-const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
+const Results = ({ rows, sampleCount, radianceOrIrradiance, csvHeader }) => {
   if (rows.length === 0) {
     return null;
   }
 
-  const sharingID = rowsToURL(rows, radianceOrIrradiance);
+  const sharingID = rowsToURL(rows, radianceOrIrradiance, csvHeader);
 
   const copySharingURL = ({ target }) => {
     target.setSelectionRange(0, target.value.length);
@@ -28,6 +28,7 @@ const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
           radianceOrIrradiance={radianceOrIrradiance}
           rows={rows}
           sampleCount={sampleCount}
+          csvHeader={csvHeader}
         />
 
         <h2 className="my-3">
@@ -39,6 +40,7 @@ const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
           rows={rows}
           sampleCount={sampleCount}
           radianceOrIrradiance={radianceOrIrradiance}
+          csvHeader={csvHeader}
         />
 
         <h2 className="my-3">
@@ -59,6 +61,7 @@ const Results = ({ rows, sampleCount, radianceOrIrradiance }) => {
           rows={rows}
           sampleCount={sampleCount}
           radianceOrIrradiance={radianceOrIrradiance}
+          csvHeader={csvHeader}
         />
 
         <h2 className="my-3">
@@ -86,6 +89,7 @@ Results.propTypes = {
   rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)).isRequired,
   sampleCount: PropTypes.number.isRequired,
   radianceOrIrradiance: PropTypes.oneOf(["radiance", "irradiance"]).isRequired,
+  csvHeader: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export default Results;

--- a/src/javascript/components/Upload.jsx
+++ b/src/javascript/components/Upload.jsx
@@ -8,6 +8,7 @@ const Upload = () => {
   );
   const [rows, setRows] = useState([]);
   const [sampleCount, setSampleCount] = useState(0);
+  const [csvHeader, setCSVHeader] = useState([]);
 
   return (
     <>
@@ -18,14 +19,17 @@ const Upload = () => {
       </div>
       <UploadForm
         radianceOrIrradiance={radianceOrIrradiance}
+        csvHeader={csvHeader}
         setRadianceOrIrradiance={setRadianceOrIrradiance}
         setRows={setRows}
         setSampleCount={setSampleCount}
+        setCSVHeader={setCSVHeader}
       />
       <Results
         rows={rows}
         sampleCount={sampleCount}
         radianceOrIrradiance={radianceOrIrradiance}
+        csvHeader={csvHeader}
       />
     </>
   );

--- a/src/javascript/components/UploadForm.jsx
+++ b/src/javascript/components/UploadForm.jsx
@@ -7,16 +7,17 @@ import ErrorTable from "./ErrorTable";
 import { relativeToAbsolute } from "../calculations";
 
 const UploadForm = ({
+  csvHeader,
   radianceOrIrradiance,
   setRadianceOrIrradiance,
   setRows,
   setSampleCount,
+  setCSVHeader,
 }) => {
   const [powerScale, setPowerScale] = useState(1);
   const [areaScale, setAreaScale] = useState(1);
   const [errors, setErrors] = useState([]);
   const [csv, setCSV] = useState([]);
-  const [csvHeader, setCSVHeader] = useState([]);
   const [absoluteOrRelative, setAbsoluteOrRelative] = useState("absolute");
   const [relativePowers, setRelativePowers] = useState({});
 
@@ -180,9 +181,11 @@ const UploadForm = ({
 
 UploadForm.propTypes = {
   radianceOrIrradiance: PropTypes.string.isRequired,
+  csvHeader: PropTypes.arrayOf(PropTypes.string).isRequired,
   setRadianceOrIrradiance: PropTypes.func.isRequired,
   setRows: PropTypes.func.isRequired,
   setSampleCount: PropTypes.func.isRequired,
+  setCSVHeader: PropTypes.func.isRequired,
 };
 
 const AbsoluteUnits = ({

--- a/src/javascript/helpers.js
+++ b/src/javascript/helpers.js
@@ -5,10 +5,6 @@ export const asExponential = (number) => {
 
 export const asDecimal = (number, precision = 2) => number.toFixed(precision);
 
-export const sampleTitles = (sampleCount) => {
-  return new Array(sampleCount).fill("").map((_, index) => `S${index}`);
-};
-
 export const radianceOrIrradianceSIUnit = (radianceOrIrradiance) => {
   let units = "";
   if (radianceOrIrradiance === "radiance") {

--- a/test/sharing.test.js
+++ b/test/sharing.test.js
@@ -2,7 +2,9 @@ import { rowsToURL, urlToRows } from "../src/javascript/sharing";
 
 describe("rowsToURL", () => {
   it("returns an empty string if there aren't enough rows", () => {
-    expect(rowsToURL([[380, 1]], "irradiance")).toEqual("");
+    expect(rowsToURL([[380, 1]], "irradiance", ["wavelength", "S1"])).toEqual(
+      ""
+    );
   });
 
   it("returns a single SPDURL if there is only one set of samples", () => {
@@ -12,9 +14,10 @@ describe("rowsToURL", () => {
           [380, 1],
           [385, 2],
         ],
-        "irradiance"
+        "irradiance",
+        ["wavelength", "S1"]
       )
-    ).toEqual("spd1,380,5,wi,5,pf6r");
+    ).toEqual("spd1,380,5,wi,5,pf6r,nS1");
   });
 
   it("returns a SPDURL with the wr unit for radiances", () => {
@@ -24,9 +27,10 @@ describe("rowsToURL", () => {
           [380, 1],
           [385, 2],
         ],
-        "radiance"
+        "radiance",
+        ["wavelength", "S1"]
       )
-    ).toEqual("spd1,380,5,wr,5,pf6r");
+    ).toEqual("spd1,380,5,wr,5,pf6r,nS1");
   });
 
   it("returns two SPDURLs joined with a pipe if there are multiple sets of samples", () => {
@@ -36,9 +40,10 @@ describe("rowsToURL", () => {
           [380, 1, 3],
           [385, 2, 4],
         ],
-        "irradiance"
+        "irradiance",
+        ["wavelength", "S1", "S2"]
       )
-    ).toEqual("spd1,380,5,wi,5,pf6r|spd1,380,5,wi,9,y06r");
+    ).toEqual("spd1,380,5,wi,5,pf6r,nS1|spd1,380,5,wi,9,y06r,nS2");
   });
 
   it("calculates the base from the first row", () => {
@@ -48,9 +53,10 @@ describe("rowsToURL", () => {
           [390, 1],
           [400, 2],
         ],
-        "irradiance"
+        "irradiance",
+        ["wavelength", "S1"]
       )
-    ).toEqual("spd1,390,10,wi,5,pf6r");
+    ).toEqual("spd1,390,10,wi,5,pf6r,nS1");
   });
 
   it("calculates the delta from the first two rows", () => {
@@ -60,9 +66,10 @@ describe("rowsToURL", () => {
           [390, 1],
           [410, 2],
         ],
-        "irradiance"
+        "irradiance",
+        ["wavelength", "S1"]
       )
-    ).toEqual("spd1,390,20,wi,5,pf6r");
+    ).toEqual("spd1,390,20,wi,5,pf6r,nS1");
   });
 });
 
@@ -110,5 +117,19 @@ describe("urlToRows", () => {
     const [rows] = urlToRows("spd1,380,5,uwi,5,pf6r");
 
     expect(rows).toEqual([]);
+  });
+
+  it("returns the data header for a single SPDURL", () => {
+    const [, , csvHeader] = urlToRows("spd1,380,5,wi,5,pf6r,nS0");
+
+    expect(csvHeader).toEqual(["wavelength", "S0"]);
+  });
+
+  it("returns the data header for multiple SPDURLs", () => {
+    const [, , csvHeader] = urlToRows(
+      "spd1,380,5,wi,5,pf6r,nS0|spd1,380,5,wi,9,y06r,nS1"
+    );
+
+    expect(csvHeader).toEqual(["wavelength", "S0", "S1"]);
   });
 });


### PR DESCRIPTION
Trello: https://trello.com/c/kGLqBgRG

Before this commit we were only using the measurement labels given in
the header row of the uploaded CSV in the options for setting the
relative power. In the chart and table we were using "S0", "S1" etc
generated by sampleTitles.

With this change we parse out the header row and pass it around the
application so that we can use it where it is needed. We map it to the
SPDURL `name` property so that it is kept when a user shares a URL.

After this change `sampleTitles` is unused, so I've removed it.