### PR TITLE
Scroll to top for each new page displayed by Router

### DIFF
--- a/src/javascript/components/App.jsx
+++ b/src/javascript/components/App.jsx
@@ -8,6 +8,7 @@ import GenerateCSV from "./GenerateCSV";
 import Upload from "./Upload";
 import Report from "./Report";
 import About from "./About";
+import ScrollToTop from "./ScrollToTop";
 
 const NavBarWithRouter = withRouter(NavBar);
 
@@ -15,6 +16,7 @@ const App = () => {
   return (
     <div>
       <Router>
+        <ScrollToTop />
         <header>
           <NavBarWithRouter />
         </header>

--- a/src/javascript/components/ScrollToTop.jsx
+++ b/src/javascript/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Trello: https://trello.com/c/iwosoe89

Previously the browser retained the same vertical position on the page when the Router loaded a new page. This was a bit odd in larger browser windows, because you would scroll down to click the "Start now" and "Next" buttons and then stay at that vertical position when the next page loaded. Now the vertical position is set back to the top of the page whenever a new page is loaded.