### PR TITLE
Display version info derived from git at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+src/version.json
 tmp

--- a/generate-version-information.sh
+++ b/generate-version-information.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+LATEST_TAG=`git tag --sort=-taggerdate | head`
+LATEST_SHA=`git rev-parse HEAD`
+echo "{ \"latestTag\": \"$LATEST_TAG\", \"latestCommitSha\": \"$LATEST_SHA\" }" > src/version.json

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "",
   "private": true,
   "scripts": {
-    "test": "prettier --check . && eslint --ext .js,.jsx *.js src test && jest",
-    "build": "mkdir -p dist && webpack --config webpack.prod.js",
-    "start": "mkdir -p dist && webpack-dev-server --open --config webpack.dev.js"
+    "version": "./generate-version-information.sh",
+    "test": "npm run version && prettier --check . && eslint --ext .js,.jsx *.js src test && jest",
+    "build": "npm run version && mkdir -p dist && webpack --config webpack.prod.js",
+    "start": "npm run version && mkdir -p dist && webpack-dev-server --open --config webpack.dev.js"
   },
   "browserslist": [
     "defaults",

--- a/src/javascript/components/About.jsx
+++ b/src/javascript/components/About.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactHtmlParser from "react-html-parser";
 import html from "./About.md";
+import version from "../../version.json";
 
 const About = () => {
   return (
@@ -8,6 +9,11 @@ const About = () => {
       <div className="col-lg-8">
         <h1 className="my-5">About this application</h1>
         {ReactHtmlParser(html)}
+        <h2 id="version-information">Version information</h2>
+        <ul>
+          <li>Latest tag: {version.latestTag}</li>
+          <li>Latest commit SHA: {version.latestCommitSha}</li>
+        </ul>
       </div>
     </div>
   );

--- a/src/javascript/components/About.md
+++ b/src/javascript/components/About.md
@@ -24,6 +24,7 @@ _A user-friendly, open-access platform for calculating quantities related to lig
   - [Source code availability and license](#source-code-availability-and-license)
   - [Alternatives](#alternatives)
 - [Acknowledgements](#acknowledgements)
+- [Version information](#version-information)
 
 ## About
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -80,6 +80,11 @@ module.exports = {
       {
         from: "_redirects",
       },
+      {
+        from: "version.json",
+        context: "src/",
+        to: ".",
+      },
     ]),
 
     new HtmlWebpackPlugin({


### PR DESCRIPTION
This is an initial stab at displaying version info suitable for https://trello.com/c/1nUvEVXs/86-display-version-information-on-about-page. I did it in a bit of a rush so I might've made mistakes and there might be a more elegant way of doing it...

<img width="619" alt="Screenshot 2021-01-22 at 17 55 42" src="https://user-images.githubusercontent.com/3169/105527215-4fb83e80-5cdb-11eb-9188-f7a2a30288d3.png">
