### PR TITLE
fix link to issues page

### DIFF
--- a/src/javascript/components/About.md
+++ b/src/javascript/components/About.md
@@ -72,7 +72,7 @@ For any support-related questions, please email [luox-support@psy.ox.ac.uk](mail
 
 ### Bug reports and feature requests
 
-To report bugs and suggest new features, please raise an issue on the project's [GitHub page](luox-support@psy.ox.ac.uk). When reporting a bug or any other issue, you need to be as specific as possible:
+To report bugs and suggest new features, please raise an issue on the project's [GitHub page](https://github.com/luox-app/luox/issues/new). When reporting a bug or any other issue, you need to be as specific as possible:
 
 - Include concrete and specific steps to reproduce your problem, including any files that pose an issue
 - If the problem only occurs occasionally but is reproducible, please include any additional contextual information


### PR DESCRIPTION
Currently the link points to the project email address rather than the issues page as stated - I've pointed it directly to creating a new issue instead. Please feel free to close this PR if this wasn't the intended behaviour :)